### PR TITLE
INA226 JSON output no trailing spaces

### DIFF
--- a/main/ZsensorINA226.ino
+++ b/main/ZsensorINA226.ino
@@ -72,9 +72,9 @@ void MeasureINA226() {
     char volt_c[7];
     char current_c[7];
     char power_c[7];
-    dtostrf(volt, 6, 3, volt_c);
-    dtostrf(current, 6, 3, current_c);
-    dtostrf(power, 6, 3, power_c);
+    dtostrf(volt, 0, 3, volt_c);
+    dtostrf(current, 0, 3, current_c);
+    dtostrf(power, 0, 3, power_c);
     INA226data["volt"] = (char*)volt_c;
     INA226data["current"] = (char*)current_c;
     INA226data["power"] = (char*)power_c;


### PR DESCRIPTION
## Description:
When the 2. parameter of dtostrf() is set to 0, then no leading or trailing spaces are generated.
Closes #1691

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
